### PR TITLE
fix: Remove environment variables from vercel.json to resolve deploym…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,10 +22,5 @@
       "src": "/(.*)",
       "dest": "frontend/$1"
     }
-  ],
-  "env": {
-    "MONGODB_URI": "@mongodb_uri",
-    "JWT_SECRET": "@jwt_secret",
-    "REACT_APP_API_URL": "https://your-vercel-app-name.vercel.app"
-  }
+  ]
 } 


### PR DESCRIPTION
…ent error\n\n- Removed env section from vercel.json that was causing deployment failure\n- Environment variables need to be set up in Vercel dashboard instead\n- Backend is already configured to use process.env variables\n- This should resolve the 'Environment Variable references Secret' error